### PR TITLE
ci: clean up test action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v1
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v2.5.1
+      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
       - uses: actions/setup-python@v2
       - uses: actions/setup-go@v3
         with:


### PR DESCRIPTION
- Node doesn't exist in this repo. No need for a setup-node action
